### PR TITLE
Add inventory feature and fix summary status

### DIFF
--- a/src/matisse/cli/reduce.py
+++ b/src/matisse/cli/reduce.py
@@ -174,9 +174,8 @@ def reduce(
             inventory=check_files,
         )
 
-        tidyup_path(Path(dir_result) / "reduced")
-
-        if not check_blocks and not check_calib:
+        if not check_blocks and not check_calib and not check_files:
+            tidyup_path(Path(dir_result) / "reduced")
             log.info(
                 "[green][SUCCESS] Results saved to reduced/ (intermediate) and reduced_OIFITS/ (oifits)"
             )

--- a/src/matisse/core/auto_pipeline.py
+++ b/src/matisse/core/auto_pipeline.py
@@ -41,9 +41,11 @@ from matisse.core.lib_auto_pipeline import (
 from matisse.core.utils.common import remove_double_parameter
 from matisse.core.utils.io_utils import resolve_raw_input
 from matisse.core.utils.log_utils import (
+    compact_missing_summary,
     console,
     iteration_banner,
     log,
+    parse_esorex_missing_files,
     save_report,
     section,
     show_blocs_status,
@@ -61,6 +63,7 @@ class RedBlock(TypedDict):
     status: int
     tplstart: str
     iter: int
+    error_msg: str
 
 
 def run_esorex(args):
@@ -129,8 +132,8 @@ def run_esorex(args):
         )
     ret = result.returncode
 
-    err_path = str(Path(workdir) / err)
-    return block_index, ret == 0, recipe, err_path
+    esorex_log_path = str(Path(workdir) / "esorex.log")
+    return block_index, ret == 0, recipe, esorex_log_path
 
 
 def run_pipeline(
@@ -168,6 +171,10 @@ def run_pipeline(
         )
     else:
         log.debug("Using current recipe parameter: spectralAverage.")
+
+    if inventory:
+        show_files_inventory(dirRaw)
+        return 0  # Exit after showing inventory if requested
 
     # --- Setup Vizier to collect MATISSE magnitudes ---
     vizier_cat_mdfc = Vizier(
@@ -221,10 +228,6 @@ def run_pipeline(
 
     # Keep a reference to all headers before filtering for skip reporting
     allhdr_all = list(allhdr)
-
-    if inventory:
-        show_files_inventory(list_raw, allhdr, console)
-        return 0  # Exit after showing inventory if requested
 
     listRawSorted = []
     allhdrSorted = []
@@ -381,6 +384,11 @@ def run_pipeline(
 
     MAX_SAFETY_ITER = 10  # Safety cap to prevent infinite loops
 
+    # Track blocks that failed esorex execution across iterations so their
+    # status is not reset when list_red_blocks is re-initialized each loop.
+    failed_tplstarts: set[str] = set()
+    failed_messages: dict[str, str] = {}
+
     iterNumber = 0
     while True:
         iterNumber += 1
@@ -421,6 +429,8 @@ def run_pipeline(
             }
             for _, iter_num in zip(keyTplStart, listIterNumber, strict=True)
         ]
+        for rb in list_red_blocks:
+            rb["error_msg"] = ""
 
         # Fill the list of raw data in the Reduction Blocks List
         log.debug("Listing files in the reduction blocks...")
@@ -798,7 +808,7 @@ def run_pipeline(
                             block_index,
                             success,
                             recipe,
-                            err_path,
+                            esorex_log,
                         ) in pool.imap_unordered(run_esorex, tasks):
                             results.append((block_index, success))
                             if success:
@@ -808,15 +818,33 @@ def run_pipeline(
                             else:
                                 progress.console.print(
                                     f"  [red]❌ Block #{block_index}[/] {recipe} "
-                                    f"— see {Path(err_path).name}"
+                                    f"— see {Path(esorex_log).name}"
                                 )
-                                failed.append((block_index, recipe, err_path))
+                                failed.append((block_index, recipe, esorex_log))
                             progress.advance(ptask)
 
                 if failed:
                     console.print(f"\n[bold red]{len(failed)} block(s) failed:[/]")
-                    for block_index, recipe, err_path in failed:
-                        console.print(f"  Block #{block_index} ({recipe}): {err_path}")
+                    for block_index, recipe, esorex_log in failed:
+                        missing_lines = parse_esorex_missing_files(esorex_log)
+                        msg = compact_missing_summary(missing_lines)
+                        # Mark block as execution-failed (status -1) and persist
+                        # its tplstart and error message across iterations.
+                        block = list_red_blocks[block_index - 1]
+                        block["status"] = -1
+                        block["error_msg"] = msg
+                        tplstart_key = block["tplstart"]
+                        failed_tplstarts.add(tplstart_key)
+                        failed_messages[tplstart_key] = msg
+                        console.print(
+                            f"  Block #{block_index} ({recipe}): {esorex_log}"
+                        )
+                        if missing_lines:
+                            console.print(
+                                "    [yellow]Missing inputs detected in esorex log:[/]"
+                            )
+                            for line in missing_lines[:10]:
+                                console.print(f"      [dim]{line}[/dim]")
 
         # Add MDFC Fluxes to CALIB_RAW_INT and TARGET_RAW_INT
         base_path = Path(repIter)
@@ -826,6 +854,13 @@ def run_pipeline(
             if p.name.endswith((".fits", ".fits.gz"))
         ]
         add_mdfc_fluxes(list_oifits_files, vizier_cat_mdfc)
+
+        # Re-apply execution-failure status and error message for blocks that
+        # failed in a previous iteration (matisse_calib resets status to 1).
+        for block in list_red_blocks:
+            if block["tplstart"] in failed_tplstarts:
+                block["status"] = -1
+                block["error_msg"] = failed_messages.get(block["tplstart"], "")
 
         if show_blocs_status(listCmdEsorex, list_red_blocks, check_blocks):
             break

--- a/src/matisse/core/auto_pipeline.py
+++ b/src/matisse/core/auto_pipeline.py
@@ -426,11 +426,10 @@ def run_pipeline(
                 "status": 0,
                 "tplstart": " ",
                 "iter": iter_num + 1,
+                "error_msg": "",
             }
             for _, iter_num in zip(keyTplStart, listIterNumber, strict=True)
         ]
-        for rb in list_red_blocks:
-            rb["error_msg"] = ""
 
         # Fill the list of raw data in the Reduction Blocks List
         log.debug("Listing files in the reduction blocks...")

--- a/src/matisse/core/utils/log_utils.py
+++ b/src/matisse/core/utils/log_utils.py
@@ -300,6 +300,20 @@ def show_blocs_status(listCmdEsorex, listRedBlocks, check_blocks):
                     msg,
                 )
                 n_skip += 1
+            elif status == -1:
+                error_msg = elt.get("error_msg", "") or "Esorex execution failed"
+                table.add_row(
+                    str(block_num),
+                    tplstart,
+                    target,
+                    tag,
+                    band,
+                    resol,
+                    action,
+                    "❌ [red]FAIL[/]",
+                    error_msg,
+                )
+                n_fail += 1
             else:
                 if elt["action"] == "NO-ACTION":
                     msg = "Data not taken into account by the Pipeline"
@@ -354,10 +368,28 @@ def show_blocs_status(listCmdEsorex, listRedBlocks, check_blocks):
     return False
 
 
-def show_files_inventory(list_raw, allhdr, console):
-    """Print table containing the different files informations."""
+def show_files_inventory(dirRaw):
+    """Print a dfits-like inventory table of raw FITS files.
+
+    Mirrors the output of:
+      dfits *.fits | fitsort obs.targ.name tpl.start det.chip.name \\
+          dpr.type ins.bcd1.name ins.bcd2.name iss.chop.st pro.catg
+    """
+    _HDR = {
+        "TARGET": "HIERARCH ESO OBS TARG NAME",
+        "TPL START": "HIERARCH ESO TPL START",
+        "CHIP": "HIERARCH ESO DET CHIP NAME",
+        "DPR TYPE": "HIERARCH ESO DPR TYPE",
+        "BCD1": "HIERARCH ESO INS BCD1 NAME",
+        "BCD2": "HIERARCH ESO INS BCD2 NAME",
+        "CHOP": "HIERARCH ESO ISS CHOP ST",
+        "PRO CATG": "HIERARCH ESO PRO CATG",
+    }
+
+    from astropy.io import fits
+
     table = Table(
-        title="\n- MATISSE inventory -",
+        title="\n- MATISSE files inventory -",
         show_header=True,
         header_style="bold magenta",
         title_style="bold cyan",
@@ -365,30 +397,35 @@ def show_files_inventory(list_raw, allhdr, console):
     )
 
     table.add_column("#", style="bold white", no_wrap=True, justify="right")
-    table.add_column("File", style="cyan")
-    table.add_column("Status", justify="center", style="bold")
-    table.add_column("Message", style="dim")
+    table.add_column("File", style="cyan", no_wrap=True)
+    for col in _HDR:
+        table.add_column(col, style="white")
 
-    # Example data, replace with actual file status
-    files = [
-        ("reduced/data1.oifits", "OK"),
-        ("reduced/data2.oifits", "SKIP"),
-        ("reduced/data3.oifits", "FAIL"),
-    ]
+    list_files = sorted(Path(dirRaw).glob("*.fits"))
 
-    for i, (filename, status) in enumerate(files, start=1):
-        if status == "OK":
-            msg = "File processed successfully"
-            table.add_row(str(i), filename, "✅ [green]OK[/]", msg)
-        elif status == "SKIP":
-            msg = "File skipped due to missing calibration"
-            table.add_row(str(i), filename, "[yellow]SKIP[/]", msg)
+    for i, filepath in enumerate(list_files):
+        hdr = fits.open(filepath)[0].header
+        chip = hdr.get(_HDR["CHIP"], "")
+        dpr_type = hdr.get(_HDR["DPR TYPE"], "")
+        if "AQUARIUS" in chip:
+            if dpr_type in ("STD", "OBJECT", "STD,RMNREC", "OBJECT,RMNREC"):
+                row_style = "yellow"
+            else:
+                row_style = "dim yellow"
+        elif "HAWAII" in chip:
+            if dpr_type in ("STD", "OBJECT", "STD,RMNREC", "OBJECT,RMNREC"):
+                row_style = ""
+            else:
+                row_style = "dim"
         else:
-            msg = "File failed to process"
-            table.add_row(str(i), filename, "❌ [red]FAIL[/]", msg)
+            row_style = "dim cyan"
+
+        values = [hdr.get(key, "–") for key in _HDR.values()]
+        table.add_row(str(i), Path(filepath).name, *values, style=row_style)
 
     console.print(table)
     _report_console.print(table)
+    return table
 
 
 def save_report(output_dir: str | Path) -> Path | None:
@@ -408,3 +445,53 @@ def save_report(output_dir: str | Path) -> Path | None:
     output_path.write_text(svg_text, encoding="utf-8")
     log.info(f"Pipeline report saved to [magenta]{output_path}[/magenta]")
     return output_path
+
+
+def parse_esorex_missing_files(log_path: str) -> list[str]:
+    """
+    Parse an esorex log file and extract lines mentioning missing files or inputs.
+
+    Returns a deduplicated list of relevant excerpts for user reporting.
+    """
+    missing: list[str] = []
+    seen: set[str] = set()
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "missing" in line.lower():
+                    stripped = line.strip()
+                    if stripped and stripped not in seen:
+                        missing.append(stripped)
+                        seen.add(stripped)
+    except (FileNotFoundError, OSError):
+        pass
+    return missing
+
+
+def compact_missing_summary(lines: list[str]) -> str:
+    """
+    Build a compact 'Missing: dark file, badpix map' string from esorex log lines.
+
+    Extracts the phrase immediately following the word "missing" (case-insensitive)
+    from each line, e.g. "missing dark file" → "dark file".
+    Falls back to a truncated first line if no such pattern is found.
+    """
+    import re
+
+    types: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        # Capture 1-3 words after "missing", ignoring leading punctuation/spaces
+        m = re.search(r"\bmissing\s+([^\n:,;]{1,40})", line, re.IGNORECASE)
+        if m:
+            phrase = m.group(1).strip().rstrip(".")
+            if phrase and phrase.lower() not in seen:
+                types.append(phrase)
+                seen.add(phrase.lower())
+    if types:
+        summary = ", ".join(types[:6])
+        return f"Missing: {summary}" + (" …" if len(types) > 6 else "")
+    if lines:
+        first = lines[0]
+        return first[:70] + ("…" if len(first) > 70 else "")
+    return "Esorex execution failed"

--- a/tests/test_auto_pipeline.py
+++ b/tests/test_auto_pipeline.py
@@ -78,7 +78,7 @@ def test_run_esorex_invokes_esorex_command(monkeypatch, tmp_path):
 
     workdir = tmp_path / "workdir"
     workdir.mkdir()
-    job_path = tmp_path / "mat_job"
+    job_path = tmp_path / "esorex"
 
     base_cmd = f"esorex --working-dir={workdir} {job_path}"
     original_cmd = f"{base_cmd} % simulated progress output"
@@ -90,7 +90,7 @@ def test_run_esorex_invokes_esorex_command(monkeypatch, tmp_path):
         block_index,
         True,
         "mat_test_recipe",
-        str(workdir / (str(job_path) + ".err")),
+        str(workdir / "esorex.log"),
     )
 
     assert captured["args"] == ["esorex", f"--working-dir={workdir}", str(job_path)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -989,3 +989,30 @@ def test_flux_calibrate_run_failure_is_reported(monkeypatch, tmp_path):
     assert result.exit_code == 1
     assert "Flux calibration failed" in output
     assert "simulated calibration crash" in output
+
+
+def test_reduce_inventory(bcd_dir):
+    """Test that --check-files calls show_files_inventory with the correct dir."""
+    from matisse.core.utils.log_utils import show_files_inventory
+
+    result = runner.invoke(
+        app,
+        [
+            "reduce",
+            "--data-dir",
+            str(bcd_dir),
+            "--check-files",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"Command failed:\n{result.output}"
+
+    # Verify the inventory function returns a table with 4 rows (one per FITS file)
+    n_fits = len(list(bcd_dir.glob("*.fits")))
+    assert n_fits == 4, f"Expected 4 FITS files in bcd_dir, found {n_fits}"
+
+    table = show_files_inventory(str(bcd_dir))
+    assert table.row_count == n_fits, (
+        f"Expected {n_fits} rows in inventory table, got {table.row_count}"
+    )


### PR DESCRIPTION
### New features

- **Add inventory**: you can now check the files listed in the current directory by using `matisse reduce --check-files`. It will display a new table summary with LM/N bands display in distinct color, associated calibration files in dimmed same color and GRA4MAT related files (RMNREC) in dimmed blue.
- **Missing input detection**: added `parse_esorex_missing_files()` which scans the
  esorex log for lines containing `"missing"` to produce a compact message displayed in case of failed blocks (e.g. `Missing: dark files `)

### Bug fixes

- **Wrong status on failure**: blocks that failed esorex execution were incorrectly
  shown as `✅ OK` in the final summary table. Root cause: `list_red_blocks` is
  re-initialized at every iteration and `matisse_calib` resets `status` back to `1`.
  Fixed by tracking `failed_tplstarts: set[str]` and `failed_messages: dict[str, str]`
  outside the loop and re-applying `status = -1` just before `show_blocs_status`.

- **Better failure log reference**: on esorex failure, the message now points to
  `esorex.log` (in the output `.rb` directory) instead of the `.sof.err` redirect
  file, which is where the actual recipe diagnostics are written.

### Tests

- **`test_reduce_inventory`**: asserts `exit_code == 0` and verifies via direct call
  to `show_files_inventory` that the returned table contains exactly 4 rows (one per
  FITS file in `bcd_dir`).