### PR TITLE
rel: bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.6.0 (2026-04-24)
+
+### Feat
+
+- add clearer message error (message with missing calibration)
+- add proper inventory table (`matisse reduce --check-files`)
+- change parameter name --spectralBinning to --spectralAverage (with backward compatibility).
+- add resol and band into in blocs_status. Change default value of band as `ALL` to reduce all available resolution (previously `LOW`)
+- add default master calibration for magic numbers
+- add sub-band option to compute metrics over L/M/N band only (for bcd)
+- perform matisse format at the end of reduce (instead of separated command). By default, `matisse reduce` produces `reduced/` and `reduced_OIFITS/`.
+
+### Fix
+
+- update change about parameters on tests and flux
+- timespan in hours for calibrator selection
+- update help with the new reduced output
+
+### Refactor
+
+- remove prefix and change default compute directory
+- add doc to calibrate (--cumul-block expert only)
+- polish log of calibrate
+- centralize outputs into single directory and drop max iter concept
+
 ## v0.5.0 (2026-03-24)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "matisse"
-version = "0.5.0"
+version = "0.6.0"
 description = "Modern and modular MATISSE interferometric data-reduction pipeline interface"
 authors = [
     { name = "Anthony Soulain - MATISSE consortium", email = "anthony.soulain@oca.eu" },

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "matisse"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy", version = "6.1.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
# PyPI Release: Latest Changes
(See [CHANGELOG.md](https://github.com/Matisse-Consortium/matisse-pipeline/blob/main/CHANGELOG.md) for full details).

## Major changes:
* **Summary Improvements:** Fixed issues to correctly handle failed blocks and added comments regarding missing calibration files.
* **Inventory Feature:** Added a new feature to list all files available in the repository (`matisse-reduce --check-files`).
* **Automated Iterations:** Removed the `-max-iter` parameter; the pipeline now performs the necessary iterations automatically and saves all outputs to `reduced/` by default.

## ⚡️ Compatibility Warning:
Significant changes are coming in the next release of the MATISSE ESO pipeline. One of the first breaking updates involves renaming the `--spectralBinning` parameter to `--spectralAverage`. Users of the current version will receive a warning notification stating that this update is forthcoming.