### PR TITLE
fix: ignore macOS AppleDouble sidecar files in inventory

### DIFF
--- a/src/matisse/core/auto_pipeline.py
+++ b/src/matisse/core/auto_pipeline.py
@@ -39,7 +39,7 @@ from matisse.core.lib_auto_pipeline import (
     probe_spectral_param_name,
 )
 from matisse.core.utils.common import remove_double_parameter
-from matisse.core.utils.io_utils import resolve_raw_input
+from matisse.core.utils.io_utils import _is_ignored_fits_sidecar, resolve_raw_input
 from matisse.core.utils.log_utils import (
     compact_missing_summary,
     console,
@@ -195,8 +195,10 @@ def run_pipeline(
     if dirCalib:
         p = Path(dirCalib)
         if p.is_dir():
-            listArchive = [str(f) for f in p.rglob("*.fits")] + [
-                str(f) for f in p.rglob("*.fits.gz")
+            listArchive = [
+                str(f) for f in p.rglob("*.fits") if not _is_ignored_fits_sidecar(f)
+            ] + [
+                str(f) for f in p.rglob("*.fits.gz") if not _is_ignored_fits_sidecar(f)
             ]
             log.info(f"Calibration directory explicitly provided: {p}")
         else:

--- a/src/matisse/core/utils/io_utils.py
+++ b/src/matisse/core/utils/io_utils.py
@@ -25,6 +25,11 @@ def _read_list_file(path: Path) -> list[str]:
     return lines
 
 
+def _is_ignored_fits_sidecar(path: Path) -> bool:
+    """Return True for macOS AppleDouble sidecar files like '._*.fits'."""
+    return path.name.startswith("._")
+
+
 def resolve_raw_input(raw_spec: str | Sequence[str]) -> tuple[list[Path], str]:
     """
     Normalize 'raw_spec' into a list of FITS file paths and detect the source type.
@@ -108,6 +113,7 @@ def resolve_raw_input(raw_spec: str | Sequence[str]) -> tuple[list[Path], str]:
         for p in paths
         if p.suffix.lower() == ".fits" or p.name.lower().endswith(".fits.gz")
     ]
+    fits = [p for p in fits if not _is_ignored_fits_sidecar(p)]
     if not fits:
         raise FileNotFoundError(
             "No FITS files found in the provided raw specification."

--- a/src/matisse/core/utils/log_utils.py
+++ b/src/matisse/core/utils/log_utils.py
@@ -402,10 +402,18 @@ def show_files_inventory(dirRaw):
     for col in _HDR:
         table.add_column(col, style="white")
 
-    list_files = sorted(Path(dirRaw).glob("*.fits"))
+    list_files = sorted(
+        p for p in Path(dirRaw).glob("*.fits") if not p.name.startswith("._")
+    )
+    skipped_invalid = 0
 
     for i, filepath in enumerate(list_files):
-        hdr = fits.open(filepath)[0].header
+        try:
+            hdr = fits.getheader(filepath, 0)
+        except Exception as err:
+            skipped_invalid += 1
+            log.warning(f"Skipping invalid FITS file in inventory: {filepath} ({err})")
+            continue
         chip = hdr.get("HIERARCH ESO DET CHIP NAME", "")
         dpr_type = hdr.get(_HDR["DPR TYPE"], "")
         pro_catg = hdr.get(_HDR["PRO CATG"], "")
@@ -447,6 +455,13 @@ def show_files_inventory(dirRaw):
 
     console.print(table)
     _report_console.print(table)
+    if skipped_invalid:
+        console.print(
+            f"[yellow]Skipped {skipped_invalid} invalid FITS file(s) in inventory.[/]"
+        )
+        _report_console.print(
+            f"Skipped {skipped_invalid} invalid FITS file(s) in inventory."
+        )
     return table
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import re
 import subprocess
 
 import pytest
+from astropy.io import fits
 from typer.testing import CliRunner
 
 from matisse.cli import format_results as format_module, show as show_module
@@ -1016,3 +1017,16 @@ def test_reduce_inventory(bcd_dir):
     assert table.row_count == n_fits, (
         f"Expected {n_fits} rows in inventory table, got {table.row_count}"
     )
+
+
+def test_show_files_inventory_ignores_appledouble_sidecar(tmp_path):
+    from matisse.core.utils.log_utils import show_files_inventory
+
+    valid = tmp_path / "MATIS_valid.fits"
+    sidecar = tmp_path / "._MATIS_valid.fits"
+
+    fits.PrimaryHDU().writeto(valid)
+    sidecar.write_text("not a fits file")
+
+    table = show_files_inventory(str(tmp_path))
+    assert table.row_count == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,6 +103,18 @@ def test_resolve_raw_input_glob_pattern(tmp_path):
     assert source == "glob pattern"
 
 
+def test_resolve_raw_input_ignores_appledouble_sidecars(tmp_path):
+    valid = tmp_path / "valid.fits"
+    sidecar = tmp_path / "._valid.fits"
+    valid.touch()
+    sidecar.touch()
+
+    files, source = io_utils.resolve_raw_input(str(tmp_path / "*.fits"))
+
+    assert source == "glob pattern"
+    assert files == [valid]
+
+
 def test_check_for_calib_file_uses_matisse_type(monkeypatch, capsys):
     calls: list[str] = []
 


### PR DESCRIPTION
This PR fixes a crash when scanning FITS files copied or extracted on macOS/exFAT volumes: hidden AppleDouble sidecar files like ._*.fits were being picked up as normal FITS inputs, and Astropy failed on them with “No SIMPLE card found.” The fix adds defensive filtering to ignore these sidecar files during raw/calibration discovery and makes the inventory reader resilient by skipping invalid FITS files with a warning instead of aborting, so valid data continue to process normally.