### PR TITLE
feat: force cal 2 sci for the TF calibration

### DIFF
--- a/src/matisse/cli/calibrate.py
+++ b/src/matisse/cli/calibrate.py
@@ -45,6 +45,11 @@ def calibrate(
         "--cumul-block/--no-cumul-block",
         help="Enable cumulBlock parameter in mat_cal_oifits (rarely used, expert only).",
     ),
+    force_sci: list[str] | None = typer.Option(
+        None,
+        "--force-sci",
+        help="Target name (HIERARCH ESO OBS TARG NAME) to treat as SCI even if classified as CALIB_RAW_INT. Repeatable. Useful when the dataset contains only calibrators.",
+    ),
     custom_recipes_dir: Path | None = typer.Option(
         None,
         "--recipe-dir",
@@ -79,6 +84,8 @@ def calibrate(
     console.print(f"[cyan]Result directory:[/] {resultdir.resolve()}")
     console.print(f"[magenta]Timespan:[/] {timespan} hours")
     console.print(f"[green]Bands:[/] {', '.join(bands)}")
+    if force_sci:
+        console.print(f"[yellow]Forced SCI targets:[/] {', '.join(force_sci)}")
     console.print(f"[dim]Verbose:[/] {'ON' if verbose else 'OFF'}")
 
     # --- 4. Validate bands ---
@@ -97,6 +104,7 @@ def calibrate(
             timespan=timespan,
             cumul_block=cumul_block,
             custom_recipes_dir=custom_recipes_dir,
+            force_sci_names=force_sci,
         )
 
         log.info(

--- a/src/matisse/core/auto_calib.py
+++ b/src/matisse/core/auto_calib.py
@@ -31,6 +31,7 @@ def run_calibration(
     timespan: float = 1,
     cumul_block: bool = True,
     custom_recipes_dir: Path | None = None,
+    force_sci_names: list[str] | None = None,
 ) -> None:
     """Run complete MATISSE calibration for specified bands.
 
@@ -48,6 +49,9 @@ def run_calibration(
         Enable cumulBlock parameter in esorex (default is True).
     custom_recipes_dir: Path | None = None, optional
         Custom directory for MATISSE recipes.
+    force_sci_names : list[str] or None, optional
+        Target names to promote from CALIB_RAW_INT to SCI in the SOF.
+        Default is None.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -61,6 +65,7 @@ def run_calibration(
             output_dir=output_dir,
             band=band_flag,
             timespan=timespan,
+            force_sci_names=force_sci_names,
         )
 
         # Process each SOF file

--- a/src/matisse/core/lib_auto_calib.py
+++ b/src/matisse/core/lib_auto_calib.py
@@ -26,6 +26,7 @@ def generate_sof_files(
     output_dir: Path,
     band: str,
     timespan: float = 1,
+    force_sci_names: list[str] | None = None,
 ) -> list[Path]:
     """Generate SOF files associating targets with calibrators.
 
@@ -39,6 +40,9 @@ def generate_sof_files(
         Spectral band flag ('-N' or '-LM').
     timespan : float, optional
         Time window in hours to associate calibrations (default is 1).
+    force_sci_names : list[str] or None, optional
+        Target names (matched against HIERARCH ESO OBS TARG NAME) to promote
+        from CALIB_RAW_INT to SCI in the generated SOF. Default is None.
 
     Returns
     -------
@@ -47,6 +51,7 @@ def generate_sof_files(
     """
     log.info(f"Scanning oifits files in [magenta]{input_dir.name}/[/]")
 
+    forced_names = set(force_sci_names or [])
     targets = []
     calibs = []
 
@@ -63,15 +68,23 @@ def generate_sof_files(
             hdr = hdul[0].header
 
         catg = hdr.get("ESO PRO CATG", "")
+        target_name = hdr.get("ESO OBS TARG NAME", "")
+        is_forced = catg == "CALIB_RAW_INT" and target_name in forced_names
 
-        if catg == "TARGET_RAW_INT":
+        if catg == "TARGET_RAW_INT" or is_forced:
+            if is_forced:
+                log.info(
+                    f"[yellow]Forcing[/] '{target_name}' as SCI (from {fits_file.name})"
+                )
             targets.append(
                 {
                     "path": fits_file,
                     "mjd": hdr["MJD-OBS"],
                     "chip": hdr["ESO DET CHIP NAME"],
                     "dit": hdr["ESO DET SEQ1 DIT"],
-                    "tplstart": hdr["ESO TPL START"],
+                    # tplstart may be missing on CAL files; fall back to MJD
+                    # so grouping still works for forced SCI.
+                    "tplstart": hdr.get("ESO TPL START") or str(hdr["MJD-OBS"]),
                 }
             )
         elif catg == "CALIB_RAW_INT":
@@ -81,6 +94,7 @@ def generate_sof_files(
                     "mjd": hdr["MJD-OBS"],
                     "chip": hdr["ESO DET CHIP NAME"],
                     "dit": hdr["ESO DET SEQ1 DIT"],
+                    "target_name": target_name,
                 }
             )
 
@@ -91,7 +105,14 @@ def generate_sof_files(
             f"No target/calibrator files found for {band.replace('-', '')} band"
         )
     elif n_targets == 0 and n_calibs > 0:
-        log.warning(f"No target files found for band {band.replace('-', '')}")
+        available = sorted({c["target_name"] for c in calibs if c["target_name"]})
+        hint = (
+            f" Available calibrator target names: {', '.join(available)}. "
+            "Use --force-sci NAME to promote one."
+            if available
+            else ""
+        )
+        log.warning(f"No target files found for band {band.replace('-', '')}.{hint}")
     elif n_targets > 0 and n_calibs == 0:
         log.warning(f"No calibrator files found for band {band.replace('-', '')}")
     else:

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -58,6 +58,26 @@ def test_generate_calibration_sof_files(data_dir, tmp_path):
         assert "TARGET_RAW_INT" in content
 
 
+def test_generate_sof_files_force_sci(data_dir, tmp_path):
+    """A CAL target name passed via force_sci_names is promoted to SCI."""
+    arbitrary_large_timespan = 300  # hours
+    # ome01_Tau is the calibrator in tests/data/MATIS_calibrator-LM_reduced.fits
+    sof_files = lac.generate_sof_files(
+        input_dir=data_dir,
+        band="-LM",
+        output_dir=tmp_path,
+        timespan=arbitrary_large_timespan,
+        force_sci_names=["ome01_Tau"],
+    )
+
+    forced_sof = next((s for s in sof_files if "calibrator" in s.name), None)
+    assert forced_sof is not None, "Expected a SOF for the forced ome01_Tau target"
+
+    content = forced_sof.read_text()
+    assert "MATIS_calibrator-LM_reduced.fits\tTARGET_RAW_INT" in content
+    assert "CALIB_RAW_INT" not in content
+
+
 def test_run_calibration_pipeline(data_dir, tmp_path, skip_without_esorex):
     """Test complete calibration pipeline (requires esorex)."""
     # Run the complete calibration pipeline


### PR DESCRIPTION
This pull request introduces a new feature to the MATISSE calibration CLI and backend: the ability to force specific calibrator targets to be treated as science targets (SCI) during calibration. This is especially useful for datasets containing only calibrators. The implementation includes updates to the CLI, core calibration logic, SOF file generation, and related documentation, as well as new tests to ensure correct behavior.

**New Feature: Forcing Calibrators as Science Targets**

* CLI Enhancement:
  - Added a new `--force-sci` option to the `calibrate` command in `calibrate.py`, allowing users to specify target names to be treated as SCI even if classified as CALIB_RAW_INT. The CLI now displays forced SCI targets when used.

* Improved Logging and User Guidance:
  - Enhanced logging to inform users when calibrator files are promoted to SCI and to provide hints about available calibrator names if no SCI targets are found.

**Testing**

* Added a dedicated test to verify that a calibrator specified via `force_sci_names` is correctly promoted to SCI in generated SOF files.