### PR TITLE
feat: improvement of the resampling of calibrators and skycalc spectra

### DIFF
--- a/src/matisse/core/flux/airmass.py
+++ b/src/matisse/core/flux/airmass.py
@@ -21,10 +21,7 @@ import subprocess
 from pathlib import Path
 
 import numpy as np
-from astropy.convolution import Box1DKernel, Gaussian1DKernel, convolve
 from astropy.io import fits
-from numpy.polynomial.polynomial import polyval
-from scipy.interpolate import interp1d
 
 from matisse.core.flux.utils import (
     find_nearest_idx,
@@ -189,82 +186,6 @@ def read_skycalc_output(fpath: Path) -> tuple[np.ndarray, np.ndarray]:
 # ---------------------------------------------------------------------------
 # Spectral resampling to real MATISSE resolution
 # ---------------------------------------------------------------------------
-
-
-def resample_to_matisse_resolution_old(
-    wl_orig: np.ndarray,
-    spec_orig: np.ndarray,
-    dl_coeffs: list[float],
-    wl_final: np.ndarray,
-    spectral_binning: float,
-    *,
-    kernel_width_px: float = 10.0,
-) -> np.ndarray:
-    """Resample a spectrum to the actual MATISSE spectral resolution.
-
-    Steps:
-    1. Build a non-uniform wavelength grid with spacing ∝ Δλ(λ).
-    2. Interpolate the input spectrum onto this grid.
-    3. Convolve with a Gaussian kernel (simulates instrumental LSF).
-    4. Interpolate back onto the final (data) wavelength grid.
-    5. Convolve with a boxcar kernel (spectral binning).
-
-    Parameters
-    ----------
-    wl_orig : np.ndarray
-        Original wavelength grid (µm).
-    spec_orig : np.ndarray
-        Original spectrum values.
-    dl_coeffs : list[float]
-        Polynomial coefficients [c0, c1, c2, c3] for Δλ(λ) via ``polyval``.
-    wl_final : np.ndarray
-        Target wavelength grid (µm) — the MATISSE data grid.
-    spectral_binning : float
-        Spectral binning factor from the reduction recipe.
-    kernel_width_px : float
-        Gaussian kernel width in pixels (default 10).
-
-    Returns
-    -------
-    np.ndarray
-        Resampled spectrum on the ``wl_final`` grid.
-    """
-    # 1. Build non-uniform grid with instrumental Δλ spacing
-    min_wl, max_wl = float(np.min(wl_orig)), float(np.max(wl_orig))
-    wl_new: list[float] = [min_wl]
-    wl = min_wl
-    while wl < max_wl:
-        wl += float(polyval(wl, dl_coeffs) / kernel_width_px)
-        wl_new.append(wl)
-    wl_arr = np.array(wl_new)
-
-    # 2. Interpolate onto instrumental grid
-    f_interp = interp1d(wl_orig, spec_orig, kind="cubic", fill_value="extrapolate")
-    spec_new = f_interp(wl_arr)
-
-    # 3. Convolve with Gaussian kernel (instrumental LSF)
-    sigma = kernel_width_px / (2.0 * np.sqrt(2.0 * np.log(2.0)))
-    kernel = Gaussian1DKernel(stddev=sigma)
-
-    # Pad edges to avoid boundary artifacts
-    half_k = int(kernel.dimension / 2.0)
-    if half_k > 0:
-        spec_new[0] = np.nanmedian(spec_new[:half_k])
-        spec_new[-1] = np.nanmedian(spec_new[-half_k:]) if half_k > 0 else spec_new[-1]
-    spec_convolved = convolve(spec_new, kernel, boundary="extend")
-
-    # 4. Interpolate back to data wavelength grid
-    f_final = interp1d(wl_arr, spec_convolved, kind="cubic", fill_value="extrapolate")
-    spec_interp = f_final(wl_final)
-
-    # 5. Apply spectral binning (boxcar convolution)
-    if spectral_binning > 1:
-        box_kernel = Box1DKernel(spectral_binning)
-        spec_final = convolve(spec_interp, box_kernel, boundary="extend")
-    else:
-        spec_final = spec_interp
-
-    return np.asarray(spec_final)
 
 
 def _resample_to_matisse_resolution(
@@ -485,47 +406,21 @@ def compute_airmass_correction(
 
     # Determination of the size of a MATISSE spectral channel (in pix)
     if "HAWAI" in detector:
-        size_spec_channel = 4.92
+        SIZE_SPEC_CHANNEL = 4.92
     elif "AQUARIUS" in detector:
-        size_spec_channel = 7.87
+        SIZE_SPEC_CHANNEL = 7.87
 
     trans_sci_final = _resample_to_matisse_resolution(
         wl_um_sci,
         trans_sci,
         wav_sci_m * 1e6,  # m → µm
-        size_spec_channel,
+        SIZE_SPEC_CHANNEL,
         nsigma,
     )
 
     trans_cal_final = _resample_to_matisse_resolution(
-        wl_um_cal, trans_cal, wav_cal_m * 1e6, size_spec_channel, nsigma
+        wl_um_cal, trans_cal, wav_cal_m * 1e6, SIZE_SPEC_CHANNEL, nsigma
     )
-
-    # old implementation of the resampling
-
-    # kernel_width_px = 10.0
-
-    # dl_coeffs_sci = get_dl_coeffs(hdul_sci)
-    # binning_sci = get_spectral_average(hdul_sci)
-    # trans_sci_final = resample_to_matisse_resolution(
-    #    wl_um_sci,
-    #    trans_sci,
-    #    dl_coeffs_sci,
-    #    wav_sci_m * 1e6,  # m → µm
-    #    binning_sci,
-    #    kernel_width_px=kernel_width_px,
-    # )
-
-    # dl_coeffs_cal = get_dl_coeffs(hdul_cal)
-    # binning_cal = get_spectral_average(hdul_cal)
-    # trans_cal_final = resample_to_matisse_resolution(
-    #    wl_um_cal,
-    #    trans_cal,
-    #    dl_coeffs_cal,
-    #    wav_cal_m * 1e6,
-    #    binning_cal,
-    #    kernel_width_px=kernel_width_px,
-    # )
 
     # --- Correction factor ---
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/src/matisse/core/flux/airmass.py
+++ b/src/matisse/core/flux/airmass.py
@@ -28,9 +28,6 @@ from scipy.interpolate import interp1d
 
 from matisse.core.flux.utils import (
     find_nearest_idx,
-    get_dl_coeffs,
-    get_dlambda,
-    get_spectral_average,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,7 +50,7 @@ def create_skycalc_input(
     *,
     wdelta: float = 0.1,
     wgrid_mode: str = "fixed_wavelength_step",
-    wres: float = 20000.0,
+    wres: float = 300000.0,
     lsf_type: str = "none",
     lsf_gauss_fwhm: float = 5.0,
 ) -> None:
@@ -194,7 +191,7 @@ def read_skycalc_output(fpath: Path) -> tuple[np.ndarray, np.ndarray]:
 # ---------------------------------------------------------------------------
 
 
-def resample_to_matisse_resolution(
+def resample_to_matisse_resolution_old(
     wl_orig: np.ndarray,
     spec_orig: np.ndarray,
     dl_coeffs: list[float],
@@ -268,6 +265,67 @@ def resample_to_matisse_resolution(
         spec_final = spec_interp
 
     return np.asarray(spec_final)
+
+
+def _resample_to_matisse_resolution(
+    wav_model: np.ndarray,
+    flux_model: np.ndarray,
+    wav_obs: np.darray,
+    size_spec_channel: float,
+    nsigma: int,
+) -> np.ndarray:
+    """Resample by weighted bin integration using a wavelength-dependent gaussian kernel (for dense model spectra).
+
+    For each wavelength of wav_obs, sums the model flux contributions
+    weighted by a wavelength-dependent gaussian kernel, within a window of +- nsigma*sigma around the local wavelength of wav_obs, where sigma is the standard deviation of the gaussian kernel.
+
+    Parameters
+    ----------
+    wav_model : np.ndarray
+        Model wavelength grid of the calibrator(same units as *wav_obs*; must be sorted ascending).
+    flux_model : np.ndarray
+        Model spectrum of the calibrator (Jy).
+    wav_obs : np.ndarray
+        Observation wavelength grid (sorted ascending).
+         Model wavelength grid of the calibrator(same units as *wav_obs*; must be sorted ascending).
+    size_spec_channel : float
+        size of a MATISSE spectral channel (in pix).
+    nsigma : int
+        size of the window considered for the gaussian averaging (in unit of sigma of the gaussian kernel).
+
+    Returns
+    -------
+    np.ndarray
+        Resampled flux on the ``wav_obs`` grid (Jy).
+    """
+
+    spec_resampled = np.zeros_like(wav_obs, dtype=np.float64)
+
+    # computation of the wavelength spacing per pixel
+    dlam = np.abs(np.gradient(wav_obs))
+    for i, lam0 in enumerate(wav_obs):
+        # lam0 = lam_out[i] + 0.5*dlam[i]
+
+        # Computation of the local gaussian kernel at lam0, corresponding to the local size of a MATISSE spectral channel (in wavelength).
+        fwhm = size_spec_channel * dlam[i]
+        sigma = fwhm / 2.355
+
+        # Size of the spectral window around lam0 where gaussian-weighted averaging will be performed on flux_model
+        mask = np.abs(wav_model - lam0) < nsigma * sigma
+
+        lam_mask = wav_model[mask]
+        f_mask = flux_model[mask]
+        # Case where we are too close to the edges of the wavelength grid
+        if len(lam_mask) < 5:
+            spec_resampled[i] = np.nan
+            continue
+
+        # Gaussian weighted averaging within the spectral window defined by mask
+        w = np.exp(-0.5 * ((lam_mask - lam0) / sigma) ** 2)
+        w /= np.sum(w)
+        spec_resampled[i] = np.sum(f_mask * w)
+
+    return spec_resampled
 
 
 # ---------------------------------------------------------------------------
@@ -368,12 +426,13 @@ def compute_airmass_correction(
     wmin_sci = float(np.min(wav_sci_m)) * 1e9  # m → nm
     wmax_sci = float(np.max(wav_sci_m)) * 1e9
     margin = 0.1 * (wmax_sci - wmin_sci)
-    dlambda_sci = get_dlambda(hdul_sci)
-
+    #    dlambda_sci = get_dlambda(hdul_sci)
     if "IR-N" in tag_sci:
         detected_band = "N"
+        detector = "AQUARIUS"
     elif "IR-LM" in tag_sci:
         detected_band = "LM"
+        detector = "HAWAII-2RG"
     else:
         detected_band = "unknown"
     logger.info(
@@ -391,7 +450,7 @@ def compute_airmass_correction(
         pwv_sci,
         wmin_sci - margin,
         wmax_sci + margin,
-        wdelta=dlambda_sci,
+        # wdelta=dlambda_sci,
     )
     if not run_skycalc(input_sci, output_sci):
         logger.warning("SkyCalc failed for SCI — returning unit correction.")
@@ -401,7 +460,7 @@ def compute_airmass_correction(
     wmin_cal = float(np.min(wav_cal_m)) * 1e9
     wmax_cal = float(np.max(wav_cal_m)) * 1e9
     margin_cal = 0.1 * (wmax_cal - wmin_cal)
-    dlambda_cal = get_dlambda(hdul_cal)
+    #   dlambda_cal = get_dlambda(hdul_cal)
 
     input_cal = skycalc_dir / f"skycalc_input_cal_{tag_cal}.txt"
     output_cal = skycalc_dir / f"skycalc_output_cal_{tag_cal}.fits"
@@ -411,7 +470,7 @@ def compute_airmass_correction(
         pwv_cal,
         wmin_cal - margin_cal,
         wmax_cal + margin_cal,
-        wdelta=dlambda_cal,
+        # wdelta=dlambda_cal,
     )
     if not run_skycalc(input_cal, output_cal):
         logger.warning("SkyCalc failed for CAL — returning unit correction.")
@@ -420,31 +479,53 @@ def compute_airmass_correction(
     # --- Read transmission spectra ---
     wl_um_sci, trans_sci = read_skycalc_output(output_sci)
     wl_um_cal, trans_cal = read_skycalc_output(output_cal)
-
     # --- Resample to MATISSE resolution ---
-    kernel_width_px = 10.0
+    # size of the spectral window in unit of sigma of the wavelength-dependent gaussian kernel applied in resample_to_matisse_resolution
+    nsigma = 5
 
-    dl_coeffs_sci = get_dl_coeffs(hdul_sci)
-    binning_sci = get_spectral_average(hdul_sci)
-    trans_sci_final = resample_to_matisse_resolution(
+    # Determination of the size of a MATISSE spectral channel (in pix)
+    if "HAWAI" in detector:
+        size_spec_channel = 4.92
+    elif "AQUARIUS" in detector:
+        size_spec_channel = 7.87
+
+    trans_sci_final = _resample_to_matisse_resolution(
         wl_um_sci,
         trans_sci,
-        dl_coeffs_sci,
         wav_sci_m * 1e6,  # m → µm
-        binning_sci,
-        kernel_width_px=kernel_width_px,
+        size_spec_channel,
+        nsigma,
     )
 
-    dl_coeffs_cal = get_dl_coeffs(hdul_cal)
-    binning_cal = get_spectral_average(hdul_cal)
-    trans_cal_final = resample_to_matisse_resolution(
-        wl_um_cal,
-        trans_cal,
-        dl_coeffs_cal,
-        wav_cal_m * 1e6,
-        binning_cal,
-        kernel_width_px=kernel_width_px,
+    trans_cal_final = _resample_to_matisse_resolution(
+        wl_um_cal, trans_cal, wav_cal_m * 1e6, size_spec_channel, nsigma
     )
+
+    # old implementation of the resampling
+
+    # kernel_width_px = 10.0
+
+    # dl_coeffs_sci = get_dl_coeffs(hdul_sci)
+    # binning_sci = get_spectral_average(hdul_sci)
+    # trans_sci_final = resample_to_matisse_resolution(
+    #    wl_um_sci,
+    #    trans_sci,
+    #    dl_coeffs_sci,
+    #    wav_sci_m * 1e6,  # m → µm
+    #    binning_sci,
+    #    kernel_width_px=kernel_width_px,
+    # )
+
+    # dl_coeffs_cal = get_dl_coeffs(hdul_cal)
+    # binning_cal = get_spectral_average(hdul_cal)
+    # trans_cal_final = resample_to_matisse_resolution(
+    #    wl_um_cal,
+    #    trans_cal,
+    #    dl_coeffs_cal,
+    #    wav_cal_m * 1e6,
+    #    binning_cal,
+    #    kernel_width_px=kernel_width_px,
+    # )
 
     # --- Correction factor ---
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/src/matisse/core/flux/airmass.py
+++ b/src/matisse/core/flux/airmass.py
@@ -270,7 +270,7 @@ def resample_to_matisse_resolution_old(
 def _resample_to_matisse_resolution(
     wav_model: np.ndarray,
     flux_model: np.ndarray,
-    wav_obs: np.darray,
+    wav_obs: np.ndarray,
     size_spec_channel: float,
     nsigma: int,
 ) -> np.ndarray:

--- a/src/matisse/core/flux/calibrator_spectrum.py
+++ b/src/matisse/core/flux/calibrator_spectrum.py
@@ -102,7 +102,10 @@ class CalibratorSpectrum:
 # STARSFLUX (online) lookup
 # ---------------------------------------------------------------------------
 
-_STARSFLUX_BASE_URL = "https://home.strw.leidenuniv.nl/~gamez/catalog/fitsfiles/Aug20"
+# _STARSFLUX_BASE_URL = "https://home.strw.leidenuniv.nl/~gamez/catalog/fitsfiles/Aug20"
+_STARSFLUX_BASE_URL = (
+    "https://home.strw.leidenuniv.nl/~gamez/catalog/fitsfilesFinal/Dec30"
+)
 
 
 def lookup_starsflux(

--- a/src/matisse/core/flux/flux_calibration.py
+++ b/src/matisse/core/flux/flux_calibration.py
@@ -193,7 +193,7 @@ def discover_oifits_files(
     for fpath in sorted(glob.glob(sci_pattern)):
         with fits.open(fpath) as hdu:
             catg = hdu[0].header.get("HIERARCH ESO PRO CATG", "")
-            if catg == "TARGET_RAW_INT":
+            if catg == "TARGET_RAW_INT" or catg == "TARGET_CAL_INT":
                 sci_paths.append(Path(fpath))
 
     if cal_name:
@@ -418,7 +418,7 @@ def calibrate_flux(
         hdr_sci["HIERARCH ESO ISS AMBI IWV30D START"]
         + hdr_sci["HIERARCH ESO ISS AMBI IWV30D END"]
     ) / 2.0
-
+    detector = hdr_sci["HIERARCH ESO DET CHIP NAME"]
     exp_sci, int_time_med_sci = _extract_exposure_times(hdul_sci)
     exp_cal, int_time_med_cal = _extract_exposure_times(hdul_cal)
 
@@ -522,7 +522,9 @@ def calibrate_flux(
 
     # 6. Resample model spectrum to observation grid
     is_dense_model = len(wav_model) > len(wav_cal_proc)
-    spectrum_resampled = resample_model_spectrum(wav_model, flux_model, wav_cal_proc)
+    spectrum_resampled = resample_model_spectrum(
+        wav_model, flux_model, wav_cal_proc, detector
+    )
     logger.info("Model spectrum resampled to %d channels.", len(spectrum_resampled))
 
     # Only generate the calibrator spectrum diagnostic for the first SCI-CAL pair to avoid redundancy

--- a/src/matisse/core/flux/transfer_function.py
+++ b/src/matisse/core/flux/transfer_function.py
@@ -83,9 +83,9 @@ def resample_model_spectrum(
 
     # Get the size of a spectral channel (in pix) depending on the detector (spectral band)
     if "HAWAII" in detector_type:
-        size_spec_channel = 4.92
+        SIZE_SPEC_CHANNEL = 4.92
     else:
-        size_spec_channel = 7.87
+        SIZE_SPEC_CHANNEL = 7.87
 
     if 2.0 * len(wav_obs) < n_model_in_range:
         # Model is much denser → bin-weighted integration
@@ -98,7 +98,7 @@ def resample_model_spectrum(
             wav_obs,
             wav_model,
             flux_model,
-            size_spec_channel,
+            SIZE_SPEC_CHANNEL,
             nsigma,
         )
     else:
@@ -106,65 +106,6 @@ def resample_model_spectrum(
         logger.debug("Model comparable/sparser → cubic interpolation.")
         f = interp1d(wav_model, flux_model, kind="cubic", bounds_error=False)
         return f(wav_obs)
-
-
-# def resample_model_spectrum(
-#    wav_model: np.ndarray,
-#    flux_model: np.ndarray,
-#    wav_obs: np.ndarray,
-# ) -> np.ndarray:
-#    """Resample a calibrator model spectrum onto the observation wavelength grid.
-
-#    Two strategies are used depending on the relative sampling:
-
-#    - If the model is **much denser** than the observation (>2× more points
-#      in the overlap region), a **bin-weighted integration** is performed
-#      to properly average the model within each observation channel.
-#    - Otherwise, a **cubic interpolation** is used.
-
-#    Parameters
-#    ----------
-#    wav_model : np.ndarray
-#        Model wavelength grid (same units as *wav_obs*; must be sorted ascending).
-#    flux_model : np.ndarray
-#        Model flux array (Jy).
-#    wav_obs : np.ndarray
-#        Observation wavelength grid (sorted ascending).
-
-#    Returns
-#    -------
-#    np.ndarray
-#        Resampled flux on the ``wav_obs`` grid (Jy).
-#    """
-#    # Build bin edges for the model grid
-#    wav_bin_lower_model, wav_bin_upper_model, d_wav_model = _compute_bin_edges(
-#        wav_model
-#    )
-
-# Check sampling ratio in the overlap region
-#    overlap_mask = (wav_model > np.nanmin(wav_obs)) & (wav_model < np.nanmax(wav_obs))
-#    n_model_in_range = int(np.nansum(overlap_mask))
-
-#    if 2.0 * len(wav_obs) < n_model_in_range:
-#        # Model is much denser → bin-weighted integration
-#        logger.debug(
-#            "Model denser than obs (%d vs %d) → bin integration.",
-#            n_model_in_range,
-#            len(wav_obs),
-#        )
-#        return _resample_by_bin_integration(
-#            wav_obs,
-#            wav_model,
-#            flux_model,
-#            wav_bin_lower_model,
-#            wav_bin_upper_model,
-#            d_wav_model,
-#        )
-#    else:
-#        # Comparable or sparser → cubic interpolation
-#        logger.debug("Model comparable/sparser → cubic interpolation.")
-#        f = interp1d(wav_model, flux_model, kind="cubic", bounds_error=False)
-#        return f(wav_obs)
 
 
 def _compute_bin_edges(

--- a/src/matisse/core/flux/transfer_function.py
+++ b/src/matisse/core/flux/transfer_function.py
@@ -43,12 +43,12 @@ logger = logging.getLogger(__name__)
 
 
 def resample_model_spectrum(
-    wav_model: np.darray,
-    flux_model: np.darray,
-    wav_obs: np.darray,
-    detector_type,
-    nsigma=5,
-) -> np.darray:
+    wav_model: np.ndarray,
+    flux_model: np.ndarray,
+    wav_obs: np.ndarray,
+    detector_type: str,
+    nsigma: int = 5,
+) -> np.ndarray:
     """Resample a calibrator model spectrum onto the MATISSE wavelength grid.
 
     Two strategies are used depending on the relative sampling:

--- a/src/matisse/core/flux/transfer_function.py
+++ b/src/matisse/core/flux/transfer_function.py
@@ -43,41 +43,49 @@ logger = logging.getLogger(__name__)
 
 
 def resample_model_spectrum(
-    wav_model: np.ndarray,
-    flux_model: np.ndarray,
-    wav_obs: np.ndarray,
-) -> np.ndarray:
-    """Resample a calibrator model spectrum onto the observation wavelength grid.
+    wav_model: np.darray,
+    flux_model: np.darray,
+    wav_obs: np.darray,
+    detector_type,
+    nsigma=5,
+) -> np.darray:
+    """Resample a calibrator model spectrum onto the MATISSE wavelength grid.
 
     Two strategies are used depending on the relative sampling:
 
     - If the model is **much denser** than the observation (>2× more points
-      in the overlap region), a **bin-weighted integration** is performed
-      to properly average the model within each observation channel.
+      in the overlap region), a wavelength-dependent gaussin kernel is computed and applied to properly average the model within each MATISSE spectral channel.
     - Otherwise, a **cubic interpolation** is used.
 
     Parameters
     ----------
     wav_model : np.ndarray
-        Model wavelength grid (same units as *wav_obs*; must be sorted ascending).
+        Model wavelength grid of the calibrator(same units as *wav_obs*; must be sorted ascending).
     flux_model : np.ndarray
-        Model flux array (Jy).
+        Model spectrum of the calibrator (Jy).
     wav_obs : np.ndarray
         Observation wavelength grid (sorted ascending).
+         Model wavelength grid of the calibrator(same units as *wav_obs*; must be sorted ascending).
+    detector_type : str
+        Detector used for the observations ("HAWAII-2RG" or "AQUARIUS").
+    nsigma : int
+        size of the window considered for the gaussian averaging (in unit of sigma of the gaussian kernel).
 
     Returns
     -------
     np.ndarray
         Resampled flux on the ``wav_obs`` grid (Jy).
     """
-    # Build bin edges for the model grid
-    wav_bin_lower_model, wav_bin_upper_model, d_wav_model = _compute_bin_edges(
-        wav_model
-    )
 
     # Check sampling ratio in the overlap region
     overlap_mask = (wav_model > np.nanmin(wav_obs)) & (wav_model < np.nanmax(wav_obs))
     n_model_in_range = int(np.nansum(overlap_mask))
+
+    # Get the size of a spectral channel (in pix) depending on the detector (spectral band)
+    if "HAWAII" in detector_type:
+        size_spec_channel = 4.92
+    else:
+        size_spec_channel = 7.87
 
     if 2.0 * len(wav_obs) < n_model_in_range:
         # Model is much denser → bin-weighted integration
@@ -86,19 +94,77 @@ def resample_model_spectrum(
             n_model_in_range,
             len(wav_obs),
         )
-        return _resample_by_bin_integration(
+        return _resample_by_gaussian_kernel(
             wav_obs,
             wav_model,
             flux_model,
-            wav_bin_lower_model,
-            wav_bin_upper_model,
-            d_wav_model,
+            size_spec_channel,
+            nsigma,
         )
     else:
         # Comparable or sparser → cubic interpolation
         logger.debug("Model comparable/sparser → cubic interpolation.")
         f = interp1d(wav_model, flux_model, kind="cubic", bounds_error=False)
         return f(wav_obs)
+
+
+# def resample_model_spectrum(
+#    wav_model: np.ndarray,
+#    flux_model: np.ndarray,
+#    wav_obs: np.ndarray,
+# ) -> np.ndarray:
+#    """Resample a calibrator model spectrum onto the observation wavelength grid.
+
+#    Two strategies are used depending on the relative sampling:
+
+#    - If the model is **much denser** than the observation (>2× more points
+#      in the overlap region), a **bin-weighted integration** is performed
+#      to properly average the model within each observation channel.
+#    - Otherwise, a **cubic interpolation** is used.
+
+#    Parameters
+#    ----------
+#    wav_model : np.ndarray
+#        Model wavelength grid (same units as *wav_obs*; must be sorted ascending).
+#    flux_model : np.ndarray
+#        Model flux array (Jy).
+#    wav_obs : np.ndarray
+#        Observation wavelength grid (sorted ascending).
+
+#    Returns
+#    -------
+#    np.ndarray
+#        Resampled flux on the ``wav_obs`` grid (Jy).
+#    """
+#    # Build bin edges for the model grid
+#    wav_bin_lower_model, wav_bin_upper_model, d_wav_model = _compute_bin_edges(
+#        wav_model
+#    )
+
+# Check sampling ratio in the overlap region
+#    overlap_mask = (wav_model > np.nanmin(wav_obs)) & (wav_model < np.nanmax(wav_obs))
+#    n_model_in_range = int(np.nansum(overlap_mask))
+
+#    if 2.0 * len(wav_obs) < n_model_in_range:
+#        # Model is much denser → bin-weighted integration
+#        logger.debug(
+#            "Model denser than obs (%d vs %d) → bin integration.",
+#            n_model_in_range,
+#            len(wav_obs),
+#        )
+#        return _resample_by_bin_integration(
+#            wav_obs,
+#            wav_model,
+#            flux_model,
+#            wav_bin_lower_model,
+#            wav_bin_upper_model,
+#            d_wav_model,
+#        )
+#    else:
+#        # Comparable or sparser → cubic interpolation
+#        logger.debug("Model comparable/sparser → cubic interpolation.")
+#        f = interp1d(wav_model, flux_model, kind="cubic", bounds_error=False)
+#        return f(wav_obs)
 
 
 def _compute_bin_edges(
@@ -120,6 +186,50 @@ def _compute_bin_edges(
     wh = np.concatenate((wav, [wav[-1] + (wav[-1] - wav[-2])]))
     wm = (wh + wl) / 2.0
     return wm[:-1], wm[1:], wm[1:] - wm[:-1]
+
+
+def _resample_by_gaussian_kernel(
+    wav_obs: np.ndarray,
+    wav_model: np.ndarray,
+    flux_model: np.ndarray,
+    size_spec_channel: float,
+    nsigma: int,
+) -> np.ndarray:
+    """Resample by weighted bin integration using a wavelength-dependent gaussian kernel (for dense model spectra).
+
+    For each wavelength of wav_obs, sums the model flux contributions
+    weighted by a wavelength-dependent gaussian kernel, within a window of +- nsigma*sigma around the local wavelength of wav_obs, where sigma is the standard deviation of the gaussian kernel.
+    """
+
+    spec_resampled = np.zeros_like(wav_obs, dtype=np.float64)
+
+    # computation of the wavelength spacing per pixel
+    dlam = np.abs(np.gradient(wav_obs))
+
+    for i, lam0 in enumerate(wav_obs):
+        # lam0 = lam_out[i] + 0.5*dlam[i]
+
+        # Computation of the local gaussian kernel at lam0, corresponding to the local size of a MATISSE spectral channel (in wavelength).
+        fwhm = size_spec_channel * dlam[i]
+        sigma = fwhm / 2.355
+
+        # Size of the spectral window around lam0 where gaussian-weighted averaging will be performed on flux_model
+        mask = np.abs(wav_model - lam0) < nsigma * sigma
+
+        lam_mask = wav_model[mask]
+        f_mask = flux_model[mask]
+
+        # Case where we are too close to the edges of the wavelength grid
+        if len(lam_mask) < 5:
+            spec_resampled[i] = np.nan
+            continue
+
+        # Gaussian weighted averaging within the spectral window defined by mask
+        w = np.exp(-0.5 * ((lam_mask - lam0) / sigma) ** 2)
+        w /= np.sum(w)
+        spec_resampled[i] = np.sum(f_mask * w)
+
+    return spec_resampled
 
 
 def _resample_by_bin_integration(


### PR DESCRIPTION
This pull request introduces improvements to the MATISSE flux calibration pipeline. The main change is the replacement of the previous binning/convolution-based resampling with a wavelength-dependent Gaussian kernel approach, which better matches the instrument's spectral resolution.

**Resampling and Spectral Resolution Improvements:**

- Replaced the previous `resample_to_matisse_resolution` function with `_resample_to_matisse_resolution`, which uses a wavelength-dependent Gaussian kernel for more accurate spectral resampling. The new method is also implemented in `transfer_function.py` as `_resample_by_gaussian_kernel`, and is now used wherever dense model spectra need to be resampled to the MATISSE grid. 

**Parameter and Logic Updates:**

- Changed the default spectral resolution parameter `wres` in `create_skycalc_input` from 20,000 to 300,000, improving the fidelity of synthetic transmission spectra.
- The detector type is now determined and passed through the flux calibration pipeline, affecting both the resampling kernel and channel size selection.

**Code Cleanup and Refactoring:**

- Removed unused imports and commented out legacy functions and parameters related to the old resampling approach. 

**Data Discovery and Calibrator Spectrum:**

- Modified `discover_oifits_files` to include files with category `TARGET_CAL_INT` as science files, improving file matching for calibration.
- Updated the default STARSFLUX calibrator spectrum base URL to the latest version.

These changes collectively improve the physical accuracy and maintainability of the flux calibration process, especially when working with high-resolution model spectra and different detector types.